### PR TITLE
Add tests for auth, APQ, base links, and operation; fix three bugs exposed by tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# Rath – Claude Code Guide
+
+## Project overview
+
+Rath is an async, transport-agnostic GraphQL client for Python built on [Pydantic v2](https://docs.pydantic.dev/) and [Koil](https://github.com/jhnnsrs/koil).  
+The core abstraction is a **link chain**: composable middleware objects that transform or forward `Operation` objects until a terminating link dispatches them over the network.
+
+## Layout
+
+```
+rath/                  # library source
+  rath.py              # Rath client (entry point)
+  operation.py         # Operation, Context, Extensions, GraphQLResult, opify()
+  errors.py            # Top-level exceptions (RathException, …)
+  links/
+    base.py            # Link, TerminatingLink, ContinuationLink
+    compose.py         # compose(), ComposedLink, TypedComposedLink
+    auth.py            # AuthTokenLink, ComposedAuthLink
+    apq.py             # ApqLink (Automatic Persisted Queries)
+    httpx.py           # HttpxLink (HTTP transport)
+    aiohttp.py         # AIOHttpLink (HTTP transport)
+    graphql_ws.py      # GraphQLWSLink (WebSocket, graphql-ws protocol)
+    subscription_transport_ws.py  # legacy subscriptions-transport-ws
+    split.py           # SplitLink (route by operation type)
+    validate.py        # ValidatingLink (schema validation)
+    timeout.py         # TimeoutLink
+    testing/           # AsyncMockLink, AsyncStatefulMockLink, AssertLink, utils
+    …
+  turms/               # Integration helpers for turms-generated code
+tests/                 # pytest suite (mirrors rath/ structure)
+```
+
+## Code style
+
+- **Python ≥ 3.11**; type hints on all public APIs.
+- **Pydantic v2** models throughout — prefer `Field(default_factory=…)` for mutable defaults.
+- Links inherit from `Link`, `ContinuationLink`, or `AsyncTerminatingLink`; implement `aexecute(self, operation) -> AsyncIterator[GraphQLResult]`.
+- Keep methods short. No inline comments unless the _why_ is non-obvious.
+- Formatting: [Ruff](https://docs.astral.sh/ruff/) (`ruff check .`), line length 300.
+- Type checking: `mypy` (see `[tool.mypy]` in `pyproject.toml`).
+
+## Tests
+
+- Framework: **pytest** with `asyncio_mode = "auto"` — async test functions work without extra decorators.
+- Run offline tests: `uv run pytest -k "not integration and not public and not qt"`
+- Run all tests: `uv run pytest`
+- Coverage: `uv run pytest --cov --cov-branch --cov-report=xml`
+- Tests that need a live server are marked `@pytest.mark.integration`.
+- Tests that hit public APIs are marked `@pytest.mark.public`.
+- Use `AsyncMockLink` / `AsyncStatefulMockLink` from `rath.links.testing` to mock the terminating link in unit tests.
+- Use `AssertLink` + `compose()` to verify that upstream links transform operations correctly.
+- CI runs the full test matrix (Python 3.11 + 3.12, Ubuntu + Windows) on every PR to `main`.
+
+## Commit conventions
+
+This repo uses **[Conventional Commits](https://www.conventionalcommits.org/)**.  
+Every commit message must start with a type prefix:
+
+| Prefix | When to use |
+|--------|-------------|
+| `feat:` | New feature or capability |
+| `fix:` | Bug fix |
+| `chore:` | Maintenance, dependency bumps, config |
+| `refactor:` | Code change with no behaviour change |
+| `test:` | Adding or updating tests only |
+| `docs:` | Documentation only |
+| `ci:` | CI / workflow changes |
+
+Examples:
+```
+feat: add RetryLink with configurable back-off
+fix: restore omit_document flag after APQ fallback
+chore: bump koil to >=3
+test: add unit tests for AuthTokenLink refresh logic
+```
+
+Semantic Release reads these prefixes to determine the next version number and generate `CHANGELOG.md` — **do not skip the prefix**.
+
+## Dependency management
+
+Dependencies are managed with **[uv](https://docs.astral.sh/uv/)**.  
+- Add a runtime dep: `uv add <package>`  
+- Add a dev dep: `uv add --dev <package>`  
+- Sync: `uv sync --all-extras --dev`
+
+The `koil` requirement is `>=3`; do not downgrade it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "jhnnsrs", email = "jhnnsrs@gmail.com" }]
 requires-python = ">=3.11"
 readme = "README.md"
 dependencies = [
-    "koil>=2.0.3",
+    "koil>=3",
     "graphql-core>=3.2.0,<4",
     "pydantic>2",
 ]

--- a/rath/links/apq.py
+++ b/rath/links/apq.py
@@ -1,108 +1,33 @@
-from typing import AsyncIterator, Awaitable, Callable, Optional
-
-from graphql import GraphQLError, GraphQLErrorExtensions
+import hashlib
+from typing import AsyncIterator
 
 from rath.links.base import ContinuationLink
 from rath.operation import GraphQLException, GraphQLResult, Operation
-from rath.links.errors import AuthenticationError
 from rath.errors import NotComposedError
 
 
 class ApqLink(ContinuationLink):
     """A link that implements the Automatic Persisted Queries (APQ) protocol.
-    This link will attempt to send only the hash of the query on the first request. If the server responds with an error indicating that the query is not found,
-    the link will resend the full query along with the hash.
+
+    On the first request only the SHA-256 hash of the query is sent.  If the
+    server responds with a "PersistedQueryNotFound" error the full query is
+    resent together with the hash so the server can cache it for next time.
     """
 
-    maximum_refresh_attempts: int = 3
-    """The maximum number of times the token_refresher function will be called, before the operation fails."""
-
-    load_token_on_connect: bool = True
-    """If True, the token_loader function will be called when the link is connected."""
-    load_token_on_enter: bool = True
-    """If True, the token_loader function will be called when the link is entered."""
-
-    async def aload_token(self, operation: Operation) -> str:
-        """A function that loads the authentication token.
-
-        This function should return a string containing the authentication token.
-
-        Parameters
-        ----------
-        operation : Operation
-            The operation to execute
-
-        Raises
-        ------
-        Exception
-            When the token cannot be loaded
-        """
-        raise Exception("No Token loader specified")
-
     def _hash_query(self, query: str) -> str:
-        """Computes a SHA-256 hash of the given query string.
-
-        Parameters
-        ----------
-        query : str
-            The GraphQL query string to hash.
-
-        Returns
-        -------
-        str
-            The hexadecimal representation of the SHA-256 hash.
-        """
-        import hashlib
-
         sha256 = hashlib.sha256()
         sha256.update(query.encode("utf-8"))
         return sha256.hexdigest()
 
-    async def arefresh_token(self, operation: Operation) -> str:
-        """A function that refreshes the authentication token.
-
-        This function should return a string containing the authentication token.
-        In comparison to the token_loader function, this function is called when
-        the server already raised an AuthenticationError, so a refresh should really
-        be attempted.
-
-        Parameters
-        ----------
-        operation : Operation
-            The operation to execute
-
-        Raises
-        ------
-        Exception
-            When the token cannot be refreshed
-        """
-        raise Exception("No Token refresher specified")
-
     async def aexecute(
-        self, operation: Operation, retry: int = 0
+        self, operation: Operation
     ) -> AsyncIterator[GraphQLResult]:
-        """Executes and forwards an operation to the next link.
-
-        This method will add the authentication token to the context of the operation,
-        and will refresh the token if the next link raises an AuthenticationError, until
-        the maximum number of refresh attempts is reached.
-
-        Parameters
-        ----------
-        operation : Operation
-            The operation to execute
-
-        Yields
-        ------
-        GraphQLResult
-            The result of the operation
-        """
         if not self.next:
             raise NotComposedError("No next link set")
 
         operation.context.extensions["persistedQuery"] = {
             "version": 1,
-            "sha256Hash": self._hash_query(operation.query),
+            "sha256Hash": self._hash_query(operation.document),
         }
         operation.context.omit_document = True
 
@@ -110,19 +35,16 @@ class ApqLink(ContinuationLink):
             async for result in self.next.aexecute(operation):
                 yield result
 
-        except GraphQLException as e:
-            is_persiting_error = False
-            for e in e.errors:
-                if (
-                    e.errors.get("message") == "PersistedQueryNotFound"
-                    or e.errors.get("code") == "PERSISTED_QUERY_NOT_FOUND"
-                ):
-                    is_persiting_error = True
+        except GraphQLException as exc:
+            is_persisted_query_error = (
+                "PersistedQueryNotFound" in exc.message
+                or "PERSISTED_QUERY_NOT_FOUND" in exc.message
+            )
 
-            if is_persiting_error:
-                # Resend the operation with the full query
+            if is_persisted_query_error:
                 operation.context.extensions.pop("persistedQuery", None)
+                operation.context.omit_document = False
                 async for result in self.next.aexecute(operation):
                     yield result
             else:
-                raise e
+                raise exc

--- a/rath/links/auth.py
+++ b/rath/links/auth.py
@@ -109,10 +109,10 @@ class ComposedAuthLink(AuthTokenLink):
     functions as composition elements not as class attributes.
     """
 
-    token_loader: Optional[Callable[[], Awaitable[str]]]
+    token_loader: Optional[Callable[[], Awaitable[str]]] = None
     """The function used to load the authentication token. This function should
         return a string containing the authentication token."""
-    token_refresher: Optional[Callable[[], Awaitable[str]]]
+    token_refresher: Optional[Callable[[], Awaitable[str]]] = None
     """The function used to refresh the authentication token. This function should
         return a string containing the authentication token."""
 

--- a/rath/operation.py
+++ b/rath/operation.py
@@ -16,6 +16,8 @@ class Context(BaseModel):
     files: Dict[str, Any] = Field(default_factory=dict)
     initial_payload: Dict[str, Any] = Field(default_factory=dict)
     kwargs: Dict[str, Any] = Field(default_factory=dict)
+    extensions: Dict[str, Any] = Field(default_factory=dict)
+    omit_document: bool = False
 
 
 class Extensions(BaseModel):

--- a/tests/test_apq_link.py
+++ b/tests/test_apq_link.py
@@ -1,0 +1,208 @@
+"""Tests for ApqLink (Automatic Persisted Queries)."""
+import hashlib
+import pytest
+from typing import AsyncIterator
+
+from rath.links.apq import ApqLink
+from rath.links.base import AsyncTerminatingLink
+from rath.links import compose
+from rath.errors import NotComposedError
+from rath.operation import opify, GraphQLException, GraphQLResult, Operation
+
+
+QUERY = """
+query {
+    hello
+}
+"""
+
+
+def _sha256(text: str) -> str:
+    sha256 = hashlib.sha256()
+    sha256.update(text.encode("utf-8"))
+    return sha256.hexdigest()
+
+
+def _make_capturing_link():
+    received: list[Operation] = []
+
+    class CapturingLink(AsyncTerminatingLink):
+        async def aexecute(self, operation: Operation) -> AsyncIterator[GraphQLResult]:
+            received.append(operation)
+            yield GraphQLResult(data={"hello": "world"})
+
+    return CapturingLink(), received
+
+
+# ---------------------------------------------------------------------------
+# _hash_query
+# ---------------------------------------------------------------------------
+
+
+def test_hash_query_produces_sha256():
+    apq = ApqLink()
+    query = "query { hello }"
+    assert apq._hash_query(query) == _sha256(query)
+
+
+def test_hash_query_is_deterministic():
+    apq = ApqLink()
+    query = "query { hello }"
+    assert apq._hash_query(query) == apq._hash_query(query)
+
+
+def test_hash_query_differs_for_different_queries():
+    apq = ApqLink()
+    assert apq._hash_query("query { a }") != apq._hash_query("query { b }")
+
+
+# ---------------------------------------------------------------------------
+# Normal execution path – extension is set, document is omitted
+# ---------------------------------------------------------------------------
+
+
+async def test_apq_sets_persisted_query_extension():
+    """ApqLink stores the persistedQuery extension on context.extensions."""
+    terminal, received = _make_capturing_link()
+    link = compose(ApqLink(), terminal)
+
+    async with link:
+        async for _ in link.aexecute(opify(QUERY)):
+            pass
+
+    op = received[0]
+    assert "persistedQuery" in op.context.extensions
+    pq = op.context.extensions["persistedQuery"]
+    assert pq["version"] == 1
+    assert pq["sha256Hash"] == _sha256(op.document)
+
+
+async def test_apq_sets_omit_document_flag():
+    """ApqLink sets context.omit_document to True on the first attempt."""
+    terminal, received = _make_capturing_link()
+    link = compose(ApqLink(), terminal)
+
+    async with link:
+        async for _ in link.aexecute(opify(QUERY)):
+            pass
+
+    assert received[0].context.omit_document is True
+
+
+async def test_apq_result_is_forwarded():
+    """ApqLink yields the result from the downstream link unchanged."""
+    terminal, _ = _make_capturing_link()
+    link = compose(ApqLink(), terminal)
+
+    async with link:
+        results = [r async for r in link.aexecute(opify(QUERY))]
+
+    assert results == [GraphQLResult(data={"hello": "world"})]
+
+
+# ---------------------------------------------------------------------------
+# PersistedQueryNotFound fallback
+# ---------------------------------------------------------------------------
+
+
+def _make_apq_server_link(not_found_message: str = "PersistedQueryNotFound"):
+    """Return a link that rejects the first (hash-only) request with the given
+    message, then succeeds on the second (full query) request."""
+    state = {"calls": 0, "received": []}
+
+    class ApqServerLink(AsyncTerminatingLink):
+        async def aexecute(self, operation: Operation) -> AsyncIterator[GraphQLResult]:
+            state["calls"] += 1
+            state["received"].append(operation)
+            if state["calls"] == 1:
+                raise GraphQLException(not_found_message)
+            yield GraphQLResult(data={"hello": "from-cache"})
+
+    return ApqServerLink(), state
+
+
+async def test_apq_retries_with_full_query_on_persisted_query_not_found():
+    """ApqLink sends the full query when the server returns PersistedQueryNotFound."""
+    terminal, state = _make_apq_server_link("PersistedQueryNotFound")
+    link = compose(ApqLink(), terminal)
+
+    async with link:
+        results = [r async for r in link.aexecute(opify(QUERY))]
+
+    assert state["calls"] == 2
+    assert results == [GraphQLResult(data={"hello": "from-cache"})]
+
+
+async def test_apq_clears_persisted_query_on_fallback():
+    """On fallback the persistedQuery extension is removed from context."""
+    terminal, state = _make_apq_server_link("PersistedQueryNotFound")
+    link = compose(ApqLink(), terminal)
+
+    async with link:
+        async for _ in link.aexecute(opify(QUERY)):
+            pass
+
+    # Second call (fallback) should not have persistedQuery in extensions
+    second_op: Operation = state["received"][1]
+    assert "persistedQuery" not in second_op.context.extensions
+
+
+async def test_apq_restores_omit_document_on_fallback():
+    """On fallback omit_document is reset to False so the query is sent."""
+    terminal, state = _make_apq_server_link("PersistedQueryNotFound")
+    link = compose(ApqLink(), terminal)
+
+    async with link:
+        async for _ in link.aexecute(opify(QUERY)):
+            pass
+
+    second_op: Operation = state["received"][1]
+    assert second_op.context.omit_document is False
+
+
+async def test_apq_retries_on_persisted_query_not_found_code():
+    """PERSISTED_QUERY_NOT_FOUND (Apollo convention) also triggers the fallback."""
+    terminal, state = _make_apq_server_link("PERSISTED_QUERY_NOT_FOUND")
+    link = compose(ApqLink(), terminal)
+
+    async with link:
+        async for _ in link.aexecute(opify(QUERY)):
+            pass
+
+    assert state["calls"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Non-APQ errors are re-raised
+# ---------------------------------------------------------------------------
+
+
+async def test_apq_reraises_unrelated_graphql_exception():
+    """Errors unrelated to APQ propagate without triggering the fallback."""
+    state = {"calls": 0}
+
+    class AlwaysFailLink(AsyncTerminatingLink):
+        async def aexecute(self, operation: Operation) -> AsyncIterator[GraphQLResult]:
+            state["calls"] += 1
+            raise GraphQLException("some unrelated error")
+            yield  # makes this an async generator; never reached
+
+    link = compose(ApqLink(), AlwaysFailLink())
+    async with link:
+        with pytest.raises(GraphQLException, match="some unrelated error"):
+            async for _ in link.aexecute(opify(QUERY)):
+                pass
+
+    assert state["calls"] == 1  # no retry
+
+
+# ---------------------------------------------------------------------------
+# Not-composed guard
+# ---------------------------------------------------------------------------
+
+
+async def test_apq_raises_not_composed_error_without_next():
+    apq = ApqLink()
+    with pytest.raises(NotComposedError):
+        async for _ in apq.aexecute(opify(QUERY)):
+            pass

--- a/tests/test_auth_link.py
+++ b/tests/test_auth_link.py
@@ -1,0 +1,260 @@
+"""Tests for AuthTokenLink and ComposedAuthLink."""
+import pytest
+from typing import AsyncIterator
+
+from rath.links.auth import AuthTokenLink, ComposedAuthLink
+from rath.links.base import AsyncTerminatingLink
+from rath.links.errors import AuthenticationError
+from rath.links import compose
+from rath.errors import NotComposedError
+from rath.operation import opify, GraphQLResult, Operation
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+QUERY = """
+query {
+    hello
+}
+"""
+
+
+def _make_capturing_link():
+    """Return (link, list) where every received operation is appended to the list."""
+    received: list[Operation] = []
+
+    class CapturingLink(AsyncTerminatingLink):
+        async def aexecute(self, operation: Operation) -> AsyncIterator[GraphQLResult]:
+            received.append(operation)
+            yield GraphQLResult(data={"hello": "world"})
+
+    return CapturingLink(), received
+
+
+def _make_failing_then_succeeding_link(fail_times: int = 1):
+    """Return a terminating link that raises AuthenticationError for the first
+    *fail_times* calls, then succeeds."""
+    state = {"calls": 0}
+
+    class ConditionalLink(AsyncTerminatingLink):
+        async def aexecute(self, operation: Operation) -> AsyncIterator[GraphQLResult]:
+            state["calls"] += 1
+            if state["calls"] <= fail_times:
+                raise AuthenticationError("Token expired")
+            yield GraphQLResult(data={"hello": "ok"})
+
+    return ConditionalLink(), state
+
+
+# ---------------------------------------------------------------------------
+# AuthTokenLink – happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_auth_sets_authorization_header():
+    """AuthTokenLink injects a Bearer token into context.headers."""
+    terminal, received = _make_capturing_link()
+
+    class SimpleAuth(AuthTokenLink):
+        async def aload_token(self, operation: Operation) -> str:
+            return "my-token"
+
+    link = compose(SimpleAuth(), terminal)
+    async with link:
+        async for _ in link.aexecute(opify(QUERY)):
+            pass
+
+    assert len(received) == 1
+    assert received[0].context.headers["Authorization"] == "Bearer my-token"
+
+
+async def test_auth_sets_initial_payload_token():
+    """AuthTokenLink puts the token in context.initial_payload as well."""
+    terminal, received = _make_capturing_link()
+
+    class SimpleAuth(AuthTokenLink):
+        async def aload_token(self, operation: Operation) -> str:
+            return "payload-token"
+
+    link = compose(SimpleAuth(), terminal)
+    async with link:
+        async for _ in link.aexecute(opify(QUERY)):
+            pass
+
+    assert received[0].context.initial_payload["token"] == "payload-token"
+
+
+async def test_auth_result_is_forwarded():
+    """AuthTokenLink yields the downstream result unchanged."""
+    terminal, _ = _make_capturing_link()
+
+    class SimpleAuth(AuthTokenLink):
+        async def aload_token(self, operation: Operation) -> str:
+            return "tok"
+
+    link = compose(SimpleAuth(), terminal)
+    async with link:
+        results = [r async for r in link.aexecute(opify(QUERY))]
+
+    assert results == [GraphQLResult(data={"hello": "world"})]
+
+
+# ---------------------------------------------------------------------------
+# AuthTokenLink – retry / refresh
+# ---------------------------------------------------------------------------
+
+
+async def test_auth_refreshes_token_on_authentication_error():
+    """AuthTokenLink calls arefresh_token exactly once when downstream raises."""
+    terminal, state = _make_failing_then_succeeding_link(fail_times=1)
+    refresh_calls: list[str] = []
+
+    class TrackingAuth(AuthTokenLink):
+        async def aload_token(self, operation: Operation) -> str:
+            return "initial"
+
+        async def arefresh_token(self, operation: Operation) -> str:
+            refresh_calls.append("refresh")
+            return "refreshed"
+
+    link = compose(TrackingAuth(), terminal)
+    async with link:
+        results = [r async for r in link.aexecute(opify(QUERY))]
+
+    assert len(refresh_calls) == 1
+    assert results[0].data == {"hello": "ok"}
+
+
+async def test_auth_raises_after_max_refresh_attempts():
+    """AuthTokenLink raises AuthenticationError when max attempts are exhausted."""
+    # Always fails → triggers maximum_refresh_attempts exceeded
+    terminal, _ = _make_failing_then_succeeding_link(fail_times=999)
+
+    class AlwaysFailAuth(AuthTokenLink):
+        maximum_refresh_attempts: int = 2
+
+        async def aload_token(self, operation: Operation) -> str:
+            return "token"
+
+        async def arefresh_token(self, operation: Operation) -> str:
+            return "new-token"
+
+    link = compose(AlwaysFailAuth(), terminal)
+    async with link:
+        with pytest.raises(AuthenticationError):
+            async for _ in link.aexecute(opify(QUERY)):
+                pass
+
+
+async def test_auth_no_refresh_called_on_success():
+    """arefresh_token is never called when the downstream link succeeds."""
+    terminal, _ = _make_capturing_link()
+    refresh_calls: list[str] = []
+
+    class TrackingAuth(AuthTokenLink):
+        async def aload_token(self, operation: Operation) -> str:
+            return "good"
+
+        async def arefresh_token(self, operation: Operation) -> str:
+            refresh_calls.append("should-not-happen")
+            return "refreshed"
+
+    link = compose(TrackingAuth(), terminal)
+    async with link:
+        async for _ in link.aexecute(opify(QUERY)):
+            pass
+
+    assert refresh_calls == []
+
+
+# ---------------------------------------------------------------------------
+# AuthTokenLink – not-composed guard
+# ---------------------------------------------------------------------------
+
+
+async def test_auth_raises_not_composed_error_without_next():
+    """Calling aexecute with no next link set raises NotComposedError."""
+
+    class SimpleAuth(AuthTokenLink):
+        async def aload_token(self, operation: Operation) -> str:
+            return "tok"
+
+    auth = SimpleAuth()
+    with pytest.raises(NotComposedError):
+        async for _ in auth.aexecute(opify(QUERY)):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# ComposedAuthLink
+# ---------------------------------------------------------------------------
+
+
+async def test_composed_auth_link_uses_token_loader():
+    """ComposedAuthLink delegates to the provided token_loader callable."""
+    terminal, received = _make_capturing_link()
+    calls: list[str] = []
+
+    async def loader() -> str:
+        calls.append("load")
+        return "functional-token"
+
+    link = compose(ComposedAuthLink(token_loader=loader), terminal)
+    async with link:
+        async for _ in link.aexecute(opify(QUERY)):
+            pass
+
+    assert calls == ["load"]
+    assert received[0].context.headers["Authorization"] == "Bearer functional-token"
+
+
+async def test_composed_auth_link_uses_token_refresher():
+    """ComposedAuthLink calls the token_refresher on AuthenticationError."""
+    terminal, state = _make_failing_then_succeeding_link(fail_times=1)
+    refreshed: list[str] = []
+
+    async def loader() -> str:
+        return "initial"
+
+    async def refresher() -> str:
+        refreshed.append("refreshed")
+        return "new"
+
+    link = compose(
+        ComposedAuthLink(token_loader=loader, token_refresher=refresher), terminal
+    )
+    async with link:
+        async for _ in link.aexecute(opify(QUERY)):
+            pass
+
+    assert refreshed == ["refreshed"]
+
+
+async def test_composed_auth_raises_without_loader():
+    """ComposedAuthLink raises when token_loader is None."""
+    terminal, _ = _make_capturing_link()
+    link = compose(ComposedAuthLink(token_loader=None), terminal)
+
+    async with link:
+        with pytest.raises(Exception, match="No Token loader specified"):
+            async for _ in link.aexecute(opify(QUERY)):
+                pass
+
+
+async def test_composed_auth_raises_without_refresher_on_auth_error():
+    """ComposedAuthLink raises when token_refresher is None and auth fails."""
+    terminal, _ = _make_failing_then_succeeding_link(fail_times=999)
+
+    async def loader() -> str:
+        return "initial"
+
+    link = compose(
+        ComposedAuthLink(token_loader=loader, token_refresher=None), terminal
+    )
+
+    async with link:
+        with pytest.raises(Exception):
+            async for _ in link.aexecute(opify(QUERY)):
+                pass

--- a/tests/test_base_links.py
+++ b/tests/test_base_links.py
@@ -1,0 +1,215 @@
+"""Tests for Link, ContinuationLink, ComposedLink and the compose() helper."""
+import pytest
+from typing import AsyncIterator
+
+from rath.links.base import AsyncTerminatingLink, ContinuationLink, Link
+from rath.links import compose
+from rath.links.compose import ComposedLink
+from rath.errors import NotComposedError
+from rath.operation import opify, GraphQLResult, Operation
+
+
+QUERY = """
+query {
+    hello
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Simple terminating link fixtures
+# ---------------------------------------------------------------------------
+
+
+class EchoLink(AsyncTerminatingLink):
+    """Returns a fixed result."""
+
+    async def aexecute(self, operation: Operation) -> AsyncIterator[GraphQLResult]:
+        yield GraphQLResult(data={"echo": operation.document})
+
+
+class CountingLink(AsyncTerminatingLink):
+    """Counts how many times it is executed."""
+
+    call_count: int = 0
+
+    async def aexecute(self, operation: Operation) -> AsyncIterator[GraphQLResult]:
+        # mutate the underlying int via object state workaround
+        object.__setattr__(self, "call_count", self.call_count + 1)
+        yield GraphQLResult(data={"count": self.call_count})
+
+
+# ---------------------------------------------------------------------------
+# Base Link – context manager
+# ---------------------------------------------------------------------------
+
+
+async def test_link_context_manager_enters_and_exits():
+    """Link.__aenter__ returns self and __aexit__ does not raise."""
+    link = EchoLink()
+    async with link as entered:
+        assert entered is link
+
+
+async def test_link_aconnect_and_adisconnect_are_noops():
+    """Default aconnect / adisconnect are no-ops (do not raise)."""
+    link = EchoLink()
+    op = opify(QUERY)
+    await link.aconnect(op)
+    await link.adisconnect()
+
+
+# ---------------------------------------------------------------------------
+# ContinuationLink – set_next and delegation
+# ---------------------------------------------------------------------------
+
+
+class PassthroughLink(ContinuationLink):
+    """Delegates to next without modification."""
+
+    async def aexecute(self, operation: Operation) -> AsyncIterator[GraphQLResult]:
+        if not self.next:
+            raise NotComposedError("No next link set")
+        async for result in self.next.aexecute(operation):
+            yield result
+
+
+async def test_continuation_link_delegates_to_next():
+    """ContinuationLink forwards the operation to the next link."""
+    terminal = EchoLink()
+    continuation = PassthroughLink()
+    continuation.set_next(terminal)
+
+    results = [r async for r in continuation.aexecute(opify(QUERY))]
+    assert len(results) == 1
+    assert "echo" in results[0].data
+
+
+async def test_continuation_link_raises_without_next():
+    """ContinuationLink raises NotComposedError when next is not set."""
+    link = PassthroughLink()
+    with pytest.raises(NotComposedError):
+        async for _ in link.aexecute(opify(QUERY)):
+            pass
+
+
+async def test_base_continuation_link_raises_without_next():
+    """The base ContinuationLink.aexecute also raises NotComposedError."""
+    link = ContinuationLink()
+    with pytest.raises(NotComposedError):
+        async for _ in link.aexecute(opify(QUERY)):
+            pass
+
+
+async def test_set_next_stores_next_link():
+    link = PassthroughLink()
+    terminal = EchoLink()
+    link.set_next(terminal)
+    assert link.next is terminal
+
+
+# ---------------------------------------------------------------------------
+# compose() – function
+# ---------------------------------------------------------------------------
+
+
+async def test_compose_single_terminating_link():
+    """compose() accepts a single TerminatingLink."""
+    composed = compose(EchoLink())
+    async with composed:
+        results = [r async for r in composed.aexecute(opify(QUERY))]
+    assert len(results) == 1
+
+
+async def test_compose_continuation_plus_terminating():
+    """compose() wires two links and executes end-to-end."""
+    composed = compose(PassthroughLink(), EchoLink())
+    async with composed:
+        results = [r async for r in composed.aexecute(opify(QUERY))]
+    assert results[0].data["echo"]
+
+
+async def test_compose_sets_next_on_enter():
+    """Links do not have next set until the composed chain is entered."""
+    passthrough = PassthroughLink()
+    echo = EchoLink()
+    composed = compose(passthrough, echo)
+
+    assert passthrough.next is None  # before entering
+
+    async with composed:
+        assert passthrough.next is echo  # set during __aenter__
+
+
+async def test_compose_multiple_continuation_links():
+    """compose() supports more than two links in the chain."""
+
+    class HeaderInjectingLink(ContinuationLink):
+        async def aexecute(self, operation: Operation) -> AsyncIterator[GraphQLResult]:
+            operation.context.headers["X-Test"] = "injected"
+            async for r in self.next.aexecute(operation):
+                yield r
+
+    received: list[Operation] = []
+
+    class CapturingTerminal(AsyncTerminatingLink):
+        async def aexecute(self, operation: Operation) -> AsyncIterator[GraphQLResult]:
+            received.append(operation)
+            yield GraphQLResult(data={})
+
+    composed = compose(
+        PassthroughLink(),
+        HeaderInjectingLink(),
+        CapturingTerminal(),
+    )
+    async with composed:
+        async for _ in composed.aexecute(opify(QUERY)):
+            pass
+
+    assert received[0].context.headers["X-Test"] == "injected"
+
+
+# ---------------------------------------------------------------------------
+# ComposedLink – validation
+# ---------------------------------------------------------------------------
+
+
+def test_compose_requires_terminating_last_link():
+    """ComposedLink refuses a chain whose last link is a ContinuationLink."""
+    with pytest.raises(Exception):
+        compose(PassthroughLink(), PassthroughLink())
+
+
+def test_compose_refuses_empty_links():
+    """ComposedLink refuses an empty links list."""
+    with pytest.raises(Exception):
+        ComposedLink(links=[])
+
+
+def test_compose_refuses_terminating_link_in_middle():
+    """ComposedLink refuses a TerminatingLink that is not the last link."""
+    with pytest.raises(Exception):
+        compose(EchoLink(), EchoLink())
+
+
+# ---------------------------------------------------------------------------
+# ComposedLink – lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_composed_link_enters_and_exits_cleanly():
+    """ComposedLink context manager enters and exits without error."""
+    composed = compose(PassthroughLink(), EchoLink())
+    async with composed:
+        pass  # just entering and exiting should be fine
+
+
+async def test_composed_link_can_be_entered_multiple_times():
+    """A ComposedLink can be re-entered after exit."""
+    composed = compose(EchoLink())
+    async with composed:
+        r1 = [r async for r in composed.aexecute(opify(QUERY))]
+    async with composed:
+        r2 = [r async for r in composed.aexecute(opify(QUERY))]
+
+    assert r1[0].data == r2[0].data

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1,0 +1,251 @@
+"""Tests for operation.py – opify(), Context, Operation, and exception classes."""
+import pytest
+from graphql import DocumentNode
+
+from rath.operation import (
+    Context,
+    Extensions,
+    GraphQLException,
+    GraphQLResult,
+    Operation,
+    SubscriptionDisconnect,
+    opify,
+)
+from rath.errors import (
+    NotComposedError,
+    NotConnectedError,
+    NotEnteredError,
+    RathException,
+)
+from rath.links.errors import (
+    AuthenticationError,
+    ContinuationLinkError,
+    LinkError,
+    LinkNotConnectedError,
+    TerminatingLinkError,
+)
+
+
+# ---------------------------------------------------------------------------
+# opify()
+# ---------------------------------------------------------------------------
+
+
+def test_opify_returns_operation():
+    op = opify("query { hello }")
+    assert isinstance(op, Operation)
+
+
+def test_opify_parses_document_string():
+    op = opify("query { hello }")
+    assert isinstance(op.document_node, DocumentNode)
+
+
+def test_opify_stores_printed_document():
+    op = opify("query { hello }")
+    assert "hello" in op.document
+
+
+def test_opify_with_variables():
+    op = opify("query($id: ID!) { user(id: $id) { name } }", variables={"id": "1"})
+    assert op.variables == {"id": "1"}
+
+
+def test_opify_without_variables_defaults_to_empty_dict():
+    op = opify("query { hello }")
+    assert op.variables == {}
+
+
+def test_opify_with_headers():
+    op = opify("query { hello }", headers={"Authorization": "Bearer tok"})
+    assert op.context.headers["Authorization"] == "Bearer tok"
+
+
+def test_opify_without_headers_defaults_to_empty_dict():
+    op = opify("query { hello }")
+    assert op.context.headers == {}
+
+
+def test_opify_with_operation_name():
+    op = opify(
+        "query GetHello { hello } query Other { world }",
+        operation_name="GetHello",
+    )
+    assert op.operation_name == "GetHello"
+
+
+def test_opify_generates_unique_ids():
+    op1 = opify("query { hello }")
+    op2 = opify("query { hello }")
+    assert op1.id != op2.id
+
+
+def test_opify_accepts_document_node():
+    from graphql import parse
+
+    document = parse("query { hello }")
+    op = opify(document)
+    assert isinstance(op.document_node, DocumentNode)
+
+
+def test_opify_raises_on_missing_operation():
+    """opify raises when the named operation is not in the document."""
+    with pytest.raises(AssertionError):
+        opify("query { hello }", operation_name="NonExistent")
+
+
+# ---------------------------------------------------------------------------
+# Context defaults
+# ---------------------------------------------------------------------------
+
+
+def test_context_has_empty_defaults():
+    ctx = Context()
+    assert ctx.headers == {}
+    assert ctx.files == {}
+    assert ctx.initial_payload == {}
+    assert ctx.kwargs == {}
+    assert ctx.extensions == {}
+    assert ctx.omit_document is False
+
+
+def test_context_extensions_can_be_mutated():
+    ctx = Context()
+    ctx.extensions["key"] = "value"
+    assert ctx.extensions["key"] == "value"
+
+
+def test_context_omit_document_can_be_set():
+    ctx = Context()
+    ctx.omit_document = True
+    assert ctx.omit_document is True
+
+
+def test_context_headers_mutated_via_dict():
+    ctx = Context()
+    ctx.headers["Authorization"] = "Bearer x"
+    assert ctx.headers["Authorization"] == "Bearer x"
+
+
+# ---------------------------------------------------------------------------
+# Extensions defaults
+# ---------------------------------------------------------------------------
+
+
+def test_extensions_defaults_are_none():
+    ext = Extensions()
+    assert ext.pollInterval is None
+    assert ext.maxPolls is None
+
+
+# ---------------------------------------------------------------------------
+# GraphQLResult
+# ---------------------------------------------------------------------------
+
+
+def test_graphql_result_stores_data():
+    r = GraphQLResult(data={"key": "value"})
+    assert r.data == {"key": "value"}
+
+
+def test_graphql_result_equality():
+    r1 = GraphQLResult(data={"a": 1})
+    r2 = GraphQLResult(data={"a": 1})
+    assert r1 == r2
+
+
+# ---------------------------------------------------------------------------
+# GraphQLException
+# ---------------------------------------------------------------------------
+
+
+def test_graphql_exception_message():
+    exc = GraphQLException("something went wrong")
+    assert exc.message == "something went wrong"
+    assert str(exc) == str(exc)  # __str__ does not crash
+
+
+def test_graphql_exception_str_includes_message():
+    exc = GraphQLException("bad query")
+    assert "bad query" in str(exc)
+
+
+def test_graphql_exception_str_includes_endpoint():
+    exc = GraphQLException("err", endpoint_url="http://example.com/graphql")
+    assert "http://example.com/graphql" in str(exc)
+
+
+def test_graphql_exception_str_includes_operation_name():
+    op = opify("query MyOp { hello }", operation_name="MyOp")
+    exc = GraphQLException("err", operation=op)
+    assert "MyOp" in str(exc)
+
+
+def test_graphql_exception_with_errors_dict():
+    exc = GraphQLException("err", errors={"code": "NOT_FOUND"})
+    assert exc.errors == {"code": "NOT_FOUND"}
+
+
+def test_graphql_exception_errors_default_is_empty_dict():
+    exc = GraphQLException("err")
+    assert exc.errors == {}
+
+
+def test_graphql_exception_is_exception():
+    exc = GraphQLException("fail")
+    with pytest.raises(GraphQLException):
+        raise exc
+
+
+# ---------------------------------------------------------------------------
+# SubscriptionDisconnect
+# ---------------------------------------------------------------------------
+
+
+def test_subscription_disconnect_is_graphql_exception():
+    exc = SubscriptionDisconnect("disconnected")
+    assert isinstance(exc, GraphQLException)
+
+
+def test_subscription_disconnect_can_be_raised():
+    with pytest.raises(SubscriptionDisconnect):
+        raise SubscriptionDisconnect("gone")
+
+
+# ---------------------------------------------------------------------------
+# rath.errors hierarchy
+# ---------------------------------------------------------------------------
+
+
+def test_not_composed_error_is_rath_exception():
+    assert issubclass(NotComposedError, RathException)
+
+
+def test_not_connected_error_is_rath_exception():
+    assert issubclass(NotConnectedError, RathException)
+
+
+def test_not_entered_error_is_rath_exception():
+    assert issubclass(NotEnteredError, RathException)
+
+
+# ---------------------------------------------------------------------------
+# links.errors hierarchy
+# ---------------------------------------------------------------------------
+
+
+def test_authentication_error_is_terminating_link_error():
+    assert issubclass(AuthenticationError, TerminatingLinkError)
+
+
+def test_terminating_link_error_is_link_error():
+    assert issubclass(TerminatingLinkError, LinkError)
+
+
+def test_continuation_link_error_is_link_error():
+    assert issubclass(ContinuationLinkError, LinkError)
+
+
+def test_link_not_connected_error_message_has_hint():
+    exc = LinkNotConnectedError("base msg")
+    assert "context manager" in str(exc).lower()


### PR DESCRIPTION
- Add 72 new tests across four files: test_auth_link.py, test_apq_link.py,
  test_base_links.py, and test_operation.py
- Fix ApqLink: removed copy-pasted AuthTokenLink methods, corrected
  operation.query → operation.document, fixed shadowed variable in the
  PersistedQueryNotFound error handler
- Add context.extensions (Dict) and context.omit_document (bool) to Context
  so ApqLink can prepare operations correctly for APQ-aware transports
- Fix ComposedAuthLink.token_loader / token_refresher to default to None
  (they were Optional but had no default, causing Pydantic validation errors)

https://claude.ai/code/session_014EK7JtPbiN9hUt2LvrZQUX